### PR TITLE
feat: dashboard layouting example

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,10 +3,11 @@
     <nav>
       <router-link to="/">Home</router-link> |
       <router-link to="/dashboard">Dashboard</router-link> |
+      <router-link to="/dashboard-example">Dashboard Example</router-link> |
       <router-link to="/case1">Common Issues with Flex</router-link> |
       <router-link to="/case2">Common Issues with Grid</router-link>
     </nav>
-    <router-view/>
+    <router-view />
   </div>
 </template>
 

--- a/src/components/Grid/DashboardOne.vue
+++ b/src/components/Grid/DashboardOne.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="dashboard resizable">
+    <aside class="dashboard__sidebar"></aside>
+    <header class="dashboard__header"></header>
+    <main class="dashboard__content"></main>
+    <footer class="dashboard__footer"></footer>
+  </div>
+</template>
+
+<script>
+export default {};
+</script>
+
+<style scoped>
+.dashboard {
+  width: 100%;
+  min-height: 600px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto 1fr auto;
+  border: 1px solid #ccc;
+}
+
+.dashboard__sidebar {
+  background: navy;
+  min-width: 200px;
+  grid-column: 1;
+  grid-row: 1 / 4;
+}
+
+.dashboard__header {
+  background: lightblue;
+  min-height: 80px;
+  /* grid-column: 2;
+  grid-row: 1 / 2; */
+}
+
+.dashboard__content {
+  background: white;
+  /* grid-column: 2;
+  grid-row: 2 / 3; */
+}
+
+.dashboard__footer {
+  background: lightcoral;
+  min-height: 80px;
+  /* grid-column: 2;
+  grid-row: 3 / 4; */
+}
+</style>

--- a/src/components/Grid/DashboardOne.vue
+++ b/src/components/Grid/DashboardOne.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="dashboard resizable">
+  <div class="dashboard resize-both">
     <aside class="dashboard__sidebar"></aside>
     <header class="dashboard__header"></header>
     <main class="dashboard__content"></main>

--- a/src/components/Grid/DashboardTwo.vue
+++ b/src/components/Grid/DashboardTwo.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="dashboard resizable">
+    <aside class="dashboard__sidebar"></aside>
+    <header class="dashboard__header"></header>
+    <main class="dashboard__content"></main>
+    <footer class="dashboard__footer"></footer>
+  </div>
+</template>
+
+<script>
+export default {};
+</script>
+
+<style scoped>
+.dashboard {
+  width: 100%;
+  min-height: 600px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto 1fr auto;
+  grid-template-areas:
+    'sidebar header'
+    'sidebar content'
+    'sidebar footer';
+  border: 1px solid #ccc;
+}
+
+.dashboard__sidebar {
+  grid-area: sidebar;
+  min-width: 200px;
+  background: orange;
+}
+
+.dashboard__header {
+  grid-area: header;
+  min-height: 80px;
+  background: maroon;
+}
+
+.dashboard__content {
+  grid-area: content;
+  background: white;
+}
+
+.dashboard__footer {
+  grid-area: footer;
+  min-height: 80px;
+  background: maroon;
+}
+</style>

--- a/src/components/Grid/DashboardTwo.vue
+++ b/src/components/Grid/DashboardTwo.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="dashboard resizable">
+  <div class="dashboard resize-both">
     <aside class="dashboard__sidebar"></aside>
     <header class="dashboard__header"></header>
     <main class="dashboard__content"></main>

--- a/src/index.css
+++ b/src/index.css
@@ -7,3 +7,8 @@
   resize: horizontal;
   overflow: auto;
 }
+
+.resize-both {
+  resize: both;
+  overflow: auto;
+}

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -16,6 +16,11 @@ const routes = [
     component: () => import('../layouts/MainPage.vue'),
   },
   {
+    path: '/dashboard-example',
+    name: 'dashboard example',
+    component: () => import('../views/DashboardExample.vue'),
+  },
+  {
     path: '/case1',
     name: 'case-one',
     component: () => import('../views/CaseOne.vue'),

--- a/src/views/DashboardExample.vue
+++ b/src/views/DashboardExample.vue
@@ -1,0 +1,49 @@
+<template>
+  <div class="container">
+    <section class="section__wrapper">
+      <h2>Dashboard Layout with Grid Template Rows/Column</h2>
+      <div class="section__container">
+        <DashboardOne />
+      </div>
+    </section>
+  </div>
+</template>
+
+<script>
+import DashboardOne from '../components/Grid/DashboardOne.vue';
+
+export default {
+  components: {
+    DashboardOne,
+  },
+};
+</script>
+
+<style lang="css" scoped>
+.container {
+  margin: 0 auto;
+  max-width: 1280px;
+  width: 100%;
+}
+
+.container h1 {
+  font-size: 2.5rem;
+  font-weight: bold;
+  margin-bottom: 2rem;
+}
+
+.section__wrapper {
+  margin: 72px 0;
+}
+
+.section__wrapper h2 {
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin-bottom: 12px;
+}
+
+.section__container {
+  display: grid;
+  place-items: center;
+}
+</style>

--- a/src/views/DashboardExample.vue
+++ b/src/views/DashboardExample.vue
@@ -6,15 +6,23 @@
         <DashboardOne />
       </div>
     </section>
+    <section class="section__wrapper">
+      <h2>Dashboard Layout with Grid Template Areas</h2>
+      <div class="section__container">
+        <DashboardTwo />
+      </div>
+    </section>
   </div>
 </template>
 
 <script>
 import DashboardOne from '../components/Grid/DashboardOne.vue';
+import DashboardTwo from '../components/Grid/DashboardTwo.vue';
 
 export default {
   components: {
     DashboardOne,
+    DashboardTwo,
   },
 };
 </script>


### PR DESCRIPTION
### Overview
Add Dashboard layout example using Grid Template Columns/Rows and Grid Template Areas

### Changes
- add `/dashboard-example` route
- add Dashboard with Grid Template Columns/Rows example
- add Dashboard with Grid Template Areas example
- add `resize-both` global css

### Preview
![flex-grid-project (1)](https://user-images.githubusercontent.com/33661143/187625038-5c54576a-dbcb-44ba-adc0-099bc2ddaf2b.png)
